### PR TITLE
Update dependencies and add santisoler as maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,3 +51,4 @@ about:
 extra:
   recipe-maintainers:
     - leouieda
+    - santisoler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,13 +16,15 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.8
     - pip
-    - setuptools_scm
+    - setuptools >=45
+    - setuptools_scm >=6.2
   run:
-    - python >=3.7
+    - python >=3.8
     - numpy >=1.19
     - attrs >=19.3.0
+    - scipy >=1.8.0
 
 test:
   imports:


### PR DESCRIPTION
Update dependencies for Boule and include `setuptools` to the host requirements with constrained minimum versions. Add @santisoler as maintainer of the feedstock.
    

